### PR TITLE
Add backwards compatibility changes & updates

### DIFF
--- a/src/core_io.h
+++ b/src/core_io.h
@@ -20,7 +20,7 @@ class UniValue;
 // core_read.cpp
 CScript ParseScript(const std::string& s);
 std::string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDecode = false);
-bool DecodeHexTx(CMutableTransaction& tx, const std::string& hex_tx, bool try_no_witness = false, bool try_witness = true);
+bool DecodeHexTx(CMutableTransaction& tx, const std::string& hex_tx, bool try_no_witness = false, bool try_witness = true, bool try_drivechain = true);
 bool DecodeHexBlk(CBlock&, const std::string& strHexBlk);
 uint256 ParseHashUV(const UniValue& v, const std::string& strName);
 uint256 ParseHashStr(const std::string&, const std::string& strName);

--- a/src/drivenet-tx.cpp
+++ b/src/drivenet-tx.cpp
@@ -806,7 +806,7 @@ static int CommandLineRawTx(int argc, char* argv[])
             if (strHexTx == "-")                 // "-" implies standard input
                 strHexTx = readStdin();
 
-            if (!DecodeHexTx(tx, strHexTx, true))
+            if (!DecodeHexTx(tx, strHexTx, true, true, true))
                 throw std::runtime_error("invalid transaction encoding");
 
             startArg = 2;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1688,6 +1688,10 @@ bool AppInitMain()
         nLocalServices = ServiceFlags(nLocalServices | NODE_WITNESS);
     }
 
+    if (chainparams.GetConsensus().vDeployments[Consensus::DEPLOYMENT_DRIVECHAINS].nTimeout != 0) {
+        nLocalServices = ServiceFlags(nLocalServices | NODE_DRIVECHAIN);
+    }
+
     // ********************************************************* Step 11: import blocks
 
     if (!CheckDiskSpace())

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -64,20 +64,21 @@ CMutableTransaction::CMutableTransaction() : nVersion(CTransaction::CURRENT_VERS
 CMutableTransaction::CMutableTransaction(const CTransaction& tx) : vin(tx.vin), vout(tx.vout), criticalData(tx.criticalData), nVersion(tx.nVersion), nLockTime(tx.nLockTime) {}
 uint256 CMutableTransaction::GetHash() const
 {
-    return SerializeHash(*this, SER_GETHASH, SERIALIZE_TRANSACTION_NO_WITNESS);
+    return SerializeHash(*this, SER_GETHASH, SERIALIZE_TRANSACTION_NO_WITNESS | SERIALIZE_TRANSACTION_NO_DRIVECHAIN);
 }
 
 uint256 CTransaction::ComputeHash() const
 {
-    return SerializeHash(*this, SER_GETHASH, SERIALIZE_TRANSACTION_NO_WITNESS);
+    return SerializeHash(*this, SER_GETHASH, SERIALIZE_TRANSACTION_NO_WITNESS | SERIALIZE_TRANSACTION_NO_DRIVECHAIN);
 }
 
 uint256 CTransaction::GetWitnessHash() const
 {
-    if (!HasWitness()) {
+    if (!HasWitness() && nVersion != 3) {
         return GetHash();
+    } else {
+        return SerializeHash(*this, SER_GETHASH, SERIALIZE_TRANSACTION_NO_DRIVECHAIN);
     }
-    return SerializeHash(*this, SER_GETHASH, 0);
 }
 
 bool CTransaction::GetBWTHash(uint256& hashRet) const

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -163,7 +163,11 @@ std::string CInv::GetCommand() const
     std::string cmd;
     if (type & MSG_WITNESS_FLAG)
         cmd.append("witness-");
+    if (type & MSG_DRIVECHAIN_FLAG)
+        cmd.append("drivechain-");
+
     int masked = type & MSG_TYPE_MASK;
+
     switch (masked)
     {
     case MSG_TX:             return cmd.append(NetMsgType::TX);

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -263,6 +263,8 @@ enum ServiceFlags : uint64_t {
     // NODE_XTHIN means the node supports Xtreme Thinblocks
     // If this is turned off then the node will not service nor make xthin requests
     NODE_XTHIN = (1 << 4),
+    // NODE_DRIVECHAIN means that this node supports DriveChain
+    NODE_DRIVECHAIN = (1 << 5),
     // NODE_NETWORK_LIMITED means the same as NODE_NETWORK with the limitation of only
     // serving the last 288 (2 day) blocks
     // See BIP159 for details on how this is implemented.
@@ -302,7 +304,7 @@ enum ServiceFlags : uint64_t {
  * should be updated appropriately to filter for the same nodes.
  */
 static ServiceFlags GetDesirableServiceFlags(ServiceFlags services) {
-    return ServiceFlags(NODE_NETWORK | NODE_WITNESS);
+    return ServiceFlags(NODE_NETWORK | NODE_WITNESS | NODE_DRIVECHAIN);
 }
 
 /**
@@ -360,6 +362,7 @@ public:
 
 /** getdata message type flags */
 const uint32_t MSG_WITNESS_FLAG = 1 << 30;
+const uint32_t MSG_DRIVECHAIN_FLAG = 1 << 29;
 const uint32_t MSG_TYPE_MASK    = 0xffffffff >> 2;
 
 /** getdata / inv message types.
@@ -377,6 +380,8 @@ enum GetDataMsg
     MSG_WITNESS_BLOCK = MSG_BLOCK | MSG_WITNESS_FLAG, //!< Defined in BIP144
     MSG_WITNESS_TX = MSG_TX | MSG_WITNESS_FLAG,       //!< Defined in BIP144
     MSG_FILTERED_WITNESS_BLOCK = MSG_FILTERED_BLOCK | MSG_WITNESS_FLAG,
+    MSG_DRIVECHAIN_BLOCK = MSG_BLOCK | MSG_WITNESS_FLAG | MSG_DRIVECHAIN_FLAG,
+    MSG_DRIVECHAIN_TX = MSG_TX | MSG_WITNESS_FLAG | MSG_DRIVECHAIN_FLAG,
 };
 
 /** inv message data */

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -921,6 +921,8 @@ QString formatServicesStr(quint64 mask)
             case NODE_WITNESS:
                 strList.append("WITNESS");
                 break;
+            case NODE_DRIVECHAIN:
+                strList.append("DRIVECHAIN");
             case NODE_XTHIN:
                 strList.append("XTHIN");
                 break;


### PR DESCRIPTION
9b2b560

* For core_read & drivenet-tx add the ability to serialize with and
without drivechain transaction extended serialization.

* Update the SerializeHash and GetWitnessHash functions in
primitives/transaction to be backwards compatible. Add
SERIALIZE_TRANSACTION_NO_DRIVECHAIN.

* Add DriveChain service & message flags to network protocol.

* Update net_processing to send backwards compatible blocks to nodes
without drivechain, without witness or without both.

3df2fd8

* Signal NODE_DRIVECHAIN to tell other nodes we support DriveChain

* Display NODE_DRIVECHAIN service flag in GUI when we connect to
another node that supports drivechain.

