### PR TITLE
GUI updates & disable loaded coins

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1739,6 +1739,15 @@ bool AppInitMain()
 
     bool fReadLoadedCoins = gArgs.GetBoolArg("-loadedcoins", true);
 
+    // TODO loaded coins are disabled for this release. Setting fReadLoadedCoins
+    // to false no matter what settings are applied means that loaded coins will
+    // not be read and cannot be used by other nodes without violating consensus
+    // rules.
+    //
+    // If loaded coins are to be removed entirely the code should be deleted.
+    // Or if loaded coins are to be re-enabled the next line can be deleted.
+    fReadLoadedCoins = false;
+
     // TODO improve this check... Right now we're just checking if the last
     // loaded coin that will be written can currently be looked up by pcoinsTip.
     // That does basically ensure that we have loaded all of the coins, but I'm

--- a/src/qt/forms/intro.ui
+++ b/src/qt/forms/intro.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>704</width>
-    <height>570</height>
+    <width>596</width>
+    <height>397</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -205,6 +205,9 @@
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
+     </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
@@ -216,13 +219,26 @@
    <item>
     <widget class="QLabel" name="lblExplanation1">
      <property name="text">
-      <string>When you click OK, %1 will begin to import the Bitcoin Core UTXO set. After that you will begin downloading new blocks.
-
-The process of catching up with the UTXO set / blockchain usually requires downloading several hundred gigabytes and can take several weeks.
-
-DriveNet will take care of this in about 5 minutes on a high end system. It will take a bit longer if you are using a VM or have slow disk IO, please be patient. 
-
-Once the Bitcoin Core UTXO set has been loaded, you may import Bitcoin Core private keys and access coins as you normally would.</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When you click OK, %1 will begin to import the Bitcoin Core UTXO set. After that you will begin downloading new blocks.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="labelLoadedCoins">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The process of catching up with the UTXO set / blockchain usually requires downloading several hundred gigabytes and can take several weeks.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;DriveNet will take care of this in about 5 minutes on a high end system. It will take a bit longer if you are using a VM or have slow disk IO, please be patient. &lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Once the Bitcoin Core UTXO set has been loaded, you may import Bitcoin Core private keys and access coins as you normally would.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -233,6 +249,9 @@ Once the Bitcoin Core UTXO set has been loaded, you may import Bitcoin Core priv
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -137,6 +137,10 @@ Intro::Intro(QWidget *parent) :
         tr("The wallet will also be stored in this directory.")
     );
     startThread();
+
+    // TODO loaded coins are disabled
+    // Remove this to re-show the loaded coins notice on the intro page
+    ui->labelLoadedCoins->setHidden(true);
 }
 
 Intro::~Intro()

--- a/src/qt/sidechainminerdialog.cpp
+++ b/src/qt/sidechainminerdialog.cpp
@@ -277,6 +277,10 @@ void SidechainMinerDialog::on_pushButtonReject_clicked()
     }
 }
 
+// TODO
+// refactor all of the voting pushButton slots to use one function for
+// setting WT^ vote type.
+
 void SidechainMinerDialog::on_pushButtonUpvoteWTPrime_clicked()
 {
     // Set WT^ vote type
@@ -380,9 +384,9 @@ void SidechainMinerDialog::on_toolButtonKeyHash_clicked()
            "Each sidechain must use a unique address or the sidechain software "
            "will be confused.\n\n"
            "The address will be based on 256 bits (encoded as 32 bytes of hex) "
-           "- you get to choose what these bits are. Either select them "
-           "yourself or click the random button, and paste these bytes into "
-           "the src/sidechain.h file.\n\n"
+           "- you get to choose what these bits are.\n\n"
+           "Add the address bytes to the src/sidechain.h file of the sidechain."
+           "\n\n"
            "Example:\n"
            "static const std::string SIDECHAIN_ADDRESS_BYTES = \"6e1f86cb9785d4484750970c7f4cd42a142d3c50974a0a3128f562934774b191\";"),
         QMessageBox::Ok);


### PR DESCRIPTION
Add comment & update miner dialog address bytes text
8f5abe8

Disable loaded coins & update intro page
a50ff50

* Disable reading of loaded coins. Ignore --loadedcoins param

* Hide loaded coins label on intro page and set size to 0x0

