### PR TITLE
http: add missing header

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -6,6 +6,7 @@
 
 #include <chainparamsbase.h>
 #include <compat.h>
+#include <deque>
 #include <util.h>
 #include <utilstrencodings.h>
 #include <netbase.h>


### PR DESCRIPTION
httpserver.cpp:73:10: error: ‘deque’ in namespace ‘std’ does not name a template type